### PR TITLE
fix: Script does not detect correctly if replica exist before trying to apply policies

### DIFF
--- a/scripts/replicate-lifecycle-policy.sh
+++ b/scripts/replicate-lifecycle-policy.sh
@@ -7,26 +7,29 @@ printf "%s/%s - Retrieve lifecycle policy from source repository.\n" "${REPOSITO
 aws ecr \
   get-lifecycle-policy \
   --repository-name "${REPOSITORY}" \
-  --region "${CURRENT_REGION}" \
-  | jq 'del(.lastEvaluatedAt)' \
-  > "${lifecycle_policy}"
+  --region "${CURRENT_REGION}" |
+  jq 'del(.lastEvaluatedAt)' \
+  >"${lifecycle_policy}"
 
-{
+should_be_replicated=$(aws ecr list-images --repository-name "${REPOSITORY}" --region "${CURRENT_REGION}" | jq -r ".imageIds | length")
+
+if [ "${should_be_replicated}" -gt 1 ]; then
   aws ecr \
     describe-repositories \
     --repository-names "${REPOSITORY}" \
     --region "${REGION}" \
-    > /dev/null 2>&1
-  printf "%s/%s - Repository exist in region.\n" "${REPOSITORY}" "${REGION}"
+    >/dev/null 2>&1
+  printf "%s/%s - Repository exists in region.\n" "${REPOSITORY}" "${REGION}"
   printf "%s/%s - Applying lifecycle policy.\n" "${REPOSITORY}" "${REGION}"
-} && {
   aws ecr \
     put-lifecycle-policy \
     --repository-name "${REPOSITORY}" \
     --region "${REGION}" \
     --cli-input-json "file://${lifecycle_policy}" \
-    > /dev/null 2>&1
-  printf "%s/%s - Policy applied.\n" "${REPOSITORY}" "${REGION}"
-}
+    >/dev/null 2>&1
+   printf "%s/%s - Policy applied.\n" "${REPOSITORY}" "${REGION}"
+else
+  printf "%s/%s - Repository is empty in %s and not replicated. Skipping.\n" "${REPOSITORY}" "${REGION}" "${CURRENT_REGION}"
+fi
 
 rm -f "${lifecycle_policy}"

--- a/scripts/replicate-lifecycle-policy.sh
+++ b/scripts/replicate-lifecycle-policy.sh
@@ -7,9 +7,9 @@ printf "%s/%s - Retrieve lifecycle policy from source repository.\n" "${REPOSITO
 aws ecr \
   get-lifecycle-policy \
   --repository-name "${REPOSITORY}" \
-  --region "${CURRENT_REGION}" |
-  jq 'del(.lastEvaluatedAt)' \
-  >"${lifecycle_policy}"
+  --region "${CURRENT_REGION}" \
+  | jq 'del(.lastEvaluatedAt)' \
+  > "${lifecycle_policy}"
 
 should_be_replicated=$(aws ecr list-images --repository-name "${REPOSITORY}" --region "${CURRENT_REGION}" | jq -r ".imageIds | length")
 
@@ -27,7 +27,7 @@ if [ "${should_be_replicated}" -gt 1 ]; then
     --region "${REGION}" \
     --cli-input-json "file://${lifecycle_policy}" \
     >/dev/null 2>&1
-   printf "%s/%s - Policy applied.\n" "${REPOSITORY}" "${REGION}"
+  printf "%s/%s - Policy applied.\n" "${REPOSITORY}" "${REGION}"
 else
   printf "%s/%s - Repository is empty in %s and not replicated. Skipping.\n" "${REPOSITORY}" "${REGION}" "${CURRENT_REGION}"
 fi


### PR DESCRIPTION
* Add check that verify if the repository contains images before trying to apply changes to the replicas. An empty repository does not have any replicas in aws ecr
* Remove useless braces since anything like { .. } && { .. } seems to ignore the -e flag in the first set of braces (this is a weird behavior)